### PR TITLE
When using `git commit -m`, print added co-authors to the terminal

### DIFF
--- a/hook-examples/prepare-commit-msg-nodejs
+++ b/hook-examples/prepare-commit-msg-nodejs
@@ -18,6 +18,12 @@ if(/COMMIT_EDITMSG/g.test(commitMessage)){
         if(contents.indexOf(stdout.trim()) !== -1) {
             process.exit(0);
         }
+        
+        // Show in console any co-authors that were added
+        if(stdout.trim().length) {
+            const cyan = '\x1b[36m%s\x1b[0m';
+            console.log(cyan, stdout.trim());
+        }
 
         const commentPos = contents.indexOf('# ');
         const gitMessage = contents.slice(0, commentPos);


### PR DESCRIPTION
Converted into issue from https://github.com/findmypast-oss/git-mob/issues/72

### Motivation

Overall git-mob is awesome, and exactly what I was looking for for pair-programming. But I found it a little surprising that using `git commit -m` didn't make it obvious when I was adding co-authors or not. That seems very easy to forget when it was on or not.

### Solution

When using `git commit -m`, this updated git commit hook will also print a cyan-colored line to the terminal for any co-authors were added. This ought to make it a lot more obvious when its on, so if commits need to be amended it can be done before pushing up off the local machine.

### Here's what it looks like: 

(co-author's name & email redacted for their privacy.  
`gacm` is my alias for `git commit add .; git commit -m`)
![image](https://user-images.githubusercontent.com/6340841/162872472-3958a92e-46f1-4bd8-8957-61bdd42eda48.png)
