### PR TITLE
Integrate solo from Git Mob Core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Change Log
+
+Follows [Semantic Versioning](https://semver.org/).
+
+## git-mob 2.3.6 Next
+
+### Added
+
+- Integrated git-mob-core solo function
+
+## git-mob-core 0.4.0 Next
+
+### Added
+
+- `updateGitTemplate` will keep global template up to date if local one is used for current repository.

--- a/packages/git-mob-core/src/commands.js
+++ b/packages/git-mob-core/src/commands.js
@@ -51,6 +51,14 @@ function usingLocalTemplate() {
   return has('--local commit.template');
 }
 
+function usingGlobalTemplate() {
+  return has('--global commit.template');
+}
+
+function getGlobalTemplate() {
+  return get('--global commit.template');
+}
+
 // Sets the option, overwriting the existing value if one exists.
 function set(key, value) {
   const { status } = silentRun(`git config ${key} "${value}"`);
@@ -90,6 +98,8 @@ module.exports = {
     removeGitMobSection,
     gitAddCoAuthor,
     usingLocalTemplate,
+    usingGlobalTemplate,
+    getGlobalTemplate,
   },
   getRepoAuthors,
 };

--- a/packages/git-mob-core/src/index.spec.ts
+++ b/packages/git-mob-core/src/index.spec.ts
@@ -80,12 +80,13 @@ describe('Git Mob API', () => {
     const authorKeys = ['ab', 'cd'];
     const authorList = buildAuthors(authorKeys);
     const mockWriteCoAuthors = jest.fn();
+    const mockRemoveCoAuthors = jest.fn();
 
     mockedMob.usingLocalTemplate.mockReturnValue(true);
     mockedGitMessage.mockReturnValue({
       writeCoAuthors: mockWriteCoAuthors,
       readCoAuthors: () => '',
-      removeCoAuthors: jest.fn(async () => ''),
+      removeCoAuthors: mockRemoveCoAuthors,
     });
 
     await updateGitTemplate(authorList);
@@ -94,13 +95,15 @@ describe('Git Mob API', () => {
     expect(mockedMob.getGlobalTemplate).toBeCalledTimes(1);
     expect(mockWriteCoAuthors).toBeCalledTimes(2);
     expect(mockWriteCoAuthors).toBeCalledWith(authorList);
+    expect(mockRemoveCoAuthors).not.toHaveBeenCalled();
   });
 
   it('update git template by removing all co-authors', async () => {
     const mockRemoveCoAuthors = jest.fn();
+    const mockWriteCoAuthors = jest.fn();
 
     mockedGitMessage.mockReturnValue({
-      writeCoAuthors: jest.fn(async () => undefined),
+      writeCoAuthors: mockWriteCoAuthors,
       readCoAuthors: () => '',
       removeCoAuthors: mockRemoveCoAuthors,
     });
@@ -108,5 +111,6 @@ describe('Git Mob API', () => {
     await updateGitTemplate();
 
     expect(mockRemoveCoAuthors).toBeCalledTimes(1);
+    expect(mockWriteCoAuthors).not.toHaveBeenCalled();
   });
 });

--- a/packages/git-mob-core/src/index.ts
+++ b/packages/git-mob-core/src/index.ts
@@ -24,7 +24,7 @@ async function setCoAuthors(keys: string[]) {
 }
 
 async function updateGitTemplate(selectedAuthors?: Author[]) {
-  const usingLocal = mob.usingLocalTemplate() && mob.usingGlobalTemplate();
+  const usingLocal = mob.usingLocalTemplate();
   const gitTemplate = gitMessage(
     resolveGitMessagePath(config.get('commit.template'))
   );

--- a/packages/git-mob-core/src/index.ts
+++ b/packages/git-mob-core/src/index.ts
@@ -33,6 +33,7 @@ async function updateGitTemplate(selectedAuthors?: Author[]) {
     if (usingLocal) {
       await gitMessage(mob.getGlobalTemplate()).writeCoAuthors(selectedAuthors);
     }
+
     return gitTemplate.writeCoAuthors(selectedAuthors);
   }
 

--- a/packages/git-mob-core/src/index.ts
+++ b/packages/git-mob-core/src/index.ts
@@ -24,11 +24,20 @@ async function setCoAuthors(keys: string[]) {
 }
 
 async function updateGitTemplate(selectedAuthors?: Author[]) {
+  const usingLocal = mob.usingLocalTemplate() && mob.usingGlobalTemplate();
   const gitTemplate = gitMessage(
     resolveGitMessagePath(config.get('commit.template'))
   );
+
   if (selectedAuthors && selectedAuthors.length > 0) {
+    if (usingLocal) {
+      await gitMessage(mob.getGlobalTemplate()).writeCoAuthors(selectedAuthors);
+    }
     return gitTemplate.writeCoAuthors(selectedAuthors);
+  }
+
+  if (usingLocal) {
+    await gitMessage(mob.getGlobalTemplate()).removeCoAuthors();
   }
 
   return gitTemplate.removeCoAuthors();

--- a/packages/git-mob/src/git-solo.spec.js
+++ b/packages/git-mob/src/git-solo.spec.js
@@ -70,6 +70,8 @@ test('ignores positional arguments', t => {
   const soloExpected = 'Thomas Anderson <neo@example.com>';
 
   t.is(soloActual, soloExpected);
+
+  unsetCommitTemplate();
 });
 
 test('warns when used outside of a git repo', t => {

--- a/packages/git-mob/src/solo.js
+++ b/packages/git-mob/src/solo.js
@@ -1,11 +1,9 @@
 import minimist from 'minimist';
 import { oneLine } from 'common-tags';
-import { getPrimaryAuthor } from 'git-mob-core';
+import { getPrimaryAuthor, solo } from 'git-mob-core';
 
-import { revParse, config } from '../src/git-commands';
-import { gitMessage, gitMessagePath } from '../src/git-message';
+import { revParse } from '../src/git-commands';
 import { checkForUpdates, runHelp, runVersion } from '../src/helpers';
-import { resetMob } from '../src/git-mob-commands';
 
 checkForUpdates();
 
@@ -35,13 +33,7 @@ runSolo();
 
 async function runSolo() {
   try {
-    await gitMessage(gitMessagePath()).removeCoAuthors();
-
-    if (config.usingLocalTemplate() && config.usingGlobalTemplate()) {
-      gitMessage(config.getGlobalTemplate()).removeCoAuthors();
-    }
-
-    resetMob();
+    await solo();
     printAuthor();
   } catch (error) {
     console.error(`Error: ${error.message}`);


### PR DESCRIPTION
Integrate the git mob core solo function into the cli.

### Question

Context: Currently, in the Git config file the key is not stored but this would make it easier to build the Author object. Might be a little more performant as you don't need to read the global co-author file and filter to out unselected authors.

Q. Should this be done now? 
A. Does not impact this integration so can be done in more relevant PR e.g. when selecting co-author

<!-- See our contributing guide https://github.com/rkotze/git-mob/blob/master/CONTRIBUTING.md -->

## Pull request checklist

<!-- Start your PR as draft and when you check all requirements below enable for review. Thanks. -->

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] I kept my pull requests small so it can be reviewed more easier

## Pull request type

Please check the type of change your PR introduces:

- [x] Refactoring (no functional changes, no api changes)
- [x] Update JS to TS

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

### More information

Important that we update the global template as well when the local template is used.

