### PR TITLE
fix(pre-commit): Remove blob/master information from raw git reposito…

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,5 +1,5 @@
 - id: add-coauthors
   name: add-coauthors
-  entry: ./blob/master/packages/git-mob/hook-examples/prepare-commit-msg-nodejs
+  entry: ./packages/git-mob/hook-examples/prepare-commit-msg-nodejs
   language: script
   stages: [prepare-commit-msg]


### PR DESCRIPTION
## Pull request checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] ~Build (`npm run build`) was run locally and any changes were pushed~
- [ ] ~All tests and linting (`npm run checks`) has passed locally and any fixes were made for failures~
- [x] I kept my pull requests small so it can be reviewed easier

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behaviour?

Removed Github references (`blob/master`) from `.pre-commit-config.yaml` as pre-commit seems to checkout the repository in raw git format.

Issue URL: [Issue #123](https://github.com/rkotze/git-mob/issues/123)

## What is the new behaviour?

`pre-commit` does not raise an error when trying to reference `prepare-commit-msg-nodejs`

- Bugfix

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Change has been tested successfully locally with `pre-commit`.
I haven't tested `git-mob core` or the `VSstudio extension`.