### PR TITLE
Fix: Create global coauthor file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Follows [Semantic Versioning](https://semver.org/).
 
 ### Fixes
 
-- Internally provide the global path for `.git-coauthors` to the overwrite function when creating it.
+- When creating a new `.git-coauthors` using the `createCoAuthorsFile` it is created only globally by providing internally the global path.
 
 ## git-mob-core 0.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Follows [Semantic Versioning](https://semver.org/).
 
+## git-mob-core 0.9.1
+
+### Fixes
+
+- Internally provide the global path for `.git-coauthors` to the overwrite function when creating it.
+
 ## git-mob-core 0.9.0
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -12171,12 +12171,12 @@
       }
     },
     "packages/git-mob": {
-      "version": "3.1.1",
+      "version": "3.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "common-tags": "^1.8.2",
-        "git-mob-core": "^0.8.2",
+        "git-mob-core": "^0.9.0",
         "minimist": "^1.2.8",
         "update-notifier": "^6.0.2"
       },
@@ -12207,7 +12207,7 @@
       }
     },
     "packages/git-mob-core": {
-      "version": "0.8.2",
+      "version": "0.9.0",
       "license": "MIT",
       "devDependencies": {
         "@jest/globals": "^29.7.0",
@@ -16492,7 +16492,7 @@
         "bob": "file:../bob",
         "common-tags": "^1.8.2",
         "eol": "^0.9.1",
-        "git-mob-core": "^0.8.2",
+        "git-mob-core": "^0.9.0",
         "minimist": "^1.2.8",
         "rimraf": "^5.0.5",
         "sinon": "^14.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12207,7 +12207,7 @@
       }
     },
     "packages/git-mob-core": {
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@jest/globals": "^29.7.0",

--- a/packages/git-mob-core/package-lock.json
+++ b/packages/git-mob-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@git-mob/core",
-  "version": "0.5.0",
+  "version": "0.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@git-mob/core",
-      "version": "0.5.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.6",

--- a/packages/git-mob-core/package.json
+++ b/packages/git-mob-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-mob-core",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Git Mob Core library to manage co-authoring",
   "homepage": "https://github.com/rkotze/git-mob/blob/master/packages/git-mob-core/README.md",
   "main": "./dist/index.js",

--- a/packages/git-mob-core/src/git-mob-api/git-authors/create-coauthors-file.spec.ts
+++ b/packages/git-mob-core/src/git-mob-api/git-authors/create-coauthors-file.spec.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 import { mockGitAuthors as mockGitAuthorsFn } from '../../test-helpers/author-mocks';
 import { Author } from '../author';
 import { createCoAuthorsFile } from './create-coauthors-file';
-import { gitAuthors } from '.';
+import { gitAuthors, globalGitCoAuthorsPath } from '.';
 
 jest.mock('node:fs');
 jest.mock('.');
@@ -23,12 +23,21 @@ test('Throw error if coauthor file exists', async () => {
 });
 
 test('Save coauthor file in home directory', async () => {
+  const defaultAuthor = {
+    pa: {
+      name: 'Placeholder Author',
+      email: 'placeholder@author.org',
+    },
+  };
   mockExistsSync.mockReturnValueOnce(false);
   const mockGitAuthorsObject = mockGitAuthorsFn(['jo', 'hu']);
   mockGitAuthors.mockReturnValue(mockGitAuthorsObject);
 
   await expect(createCoAuthorsFile()).resolves.toEqual(true);
-  expect(mockGitAuthorsObject.overwrite).toHaveBeenCalled();
+  expect(mockGitAuthorsObject.overwrite).toHaveBeenCalledWith(
+    { coauthors: defaultAuthor },
+    globalGitCoAuthorsPath()
+  );
 });
 
 test('Save coauthor file with defined coauthor list', async () => {
@@ -49,7 +58,10 @@ test('Save coauthor file with defined coauthor list', async () => {
     createCoAuthorsFile([new Author('rk', 'rich kid', 'richkid@gmail.com')])
   ).resolves.toEqual(true);
 
-  expect(mockGitAuthorsObject.overwrite).toHaveBeenCalledWith({
-    coauthors: expectAuthor,
-  });
+  expect(mockGitAuthorsObject.overwrite).toHaveBeenCalledWith(
+    {
+      coauthors: expectAuthor,
+    },
+    globalGitCoAuthorsPath()
+  );
 });

--- a/packages/git-mob-core/src/git-mob-api/git-authors/create-coauthors-file.ts
+++ b/packages/git-mob-core/src/git-mob-api/git-authors/create-coauthors-file.ts
@@ -4,14 +4,14 @@ import { gitAuthors, gitCoauthorsFileName, globalGitCoAuthorsPath } from './inde
 
 const coAuthorSchema = {
   coauthors: {
-    hh: {
-      name: 'Hulk Hogan',
-      email: 'hulk_hogan22@hotmail.org',
+    pa: {
+      name: 'Placeholder Author',
+      email: 'placeholder@author.org',
     },
   },
 };
 
-export async function createCoAuthorsFile(authorList: Author[]): Promise<boolean> {
+export async function createCoAuthorsFile(authorList?: Author[]): Promise<boolean> {
   const authorOps = gitAuthors();
   const coAuthorFilePath: string = globalGitCoAuthorsPath();
   if (existsSync(coAuthorFilePath)) {
@@ -20,9 +20,9 @@ export async function createCoAuthorsFile(authorList: Author[]): Promise<boolean
 
   if (authorList && authorList.length > 0) {
     const schema = authorOps.toObject(authorList);
-    await authorOps.overwrite(schema);
+    await authorOps.overwrite(schema, coAuthorFilePath);
   } else {
-    await authorOps.overwrite(coAuthorSchema);
+    await authorOps.overwrite(coAuthorSchema, coAuthorFilePath);
   }
 
   return true;

--- a/packages/git-mob-core/src/git-mob-api/git-authors/index.ts
+++ b/packages/git-mob-core/src/git-mob-api/git-authors/index.ts
@@ -14,18 +14,18 @@ export function gitAuthors(
   overwriteFilePromise?: () => Promise<void>
 ) {
   return {
-    read: async () => {
+    read: async (path?: string) => {
       const readPromise = readFilePromise || promisify(fs.readFile);
       const authorJsonString = (await readPromise(
-        await pathToCoAuthors()
+        path || (await pathToCoAuthors())
       )) as string;
       return JSON.parse(authorJsonString) as CoAuthorSchema;
     },
 
-    overwrite: async (authorJson: CoAuthorSchema) => {
+    overwrite: async (authorJson: CoAuthorSchema, path?: string) => {
       const overwritePromise = overwriteFilePromise || promisify(fs.writeFile);
       return overwritePromise(
-        await pathToCoAuthors(),
+        path || (await pathToCoAuthors()),
         JSON.stringify(authorJson, null, 2)
       );
     },

--- a/packages/git-mob-core/src/test-helpers/author-mocks.ts
+++ b/packages/git-mob-core/src/test-helpers/author-mocks.ts
@@ -24,8 +24,6 @@ export function mockGitAuthors(keys: string[]) {
   return {
     read: jest.fn(async () => coAuthors),
     overwrite: jest.fn(async () => ''),
-    coAuthors: jest.fn(() => []),
-    author: jest.fn(() => ({})),
     toList: jest.fn(() => authors),
     toObject: jest.fn(() => ({ coauthors: {} })),
   };


### PR DESCRIPTION
## Description

When creating the global git-coauthor file provide the global path internally instead of using the pathToCoAuthors fn.

## Pull request checklist

<!-- Start your PR as draft and when you check all requirements below enable for review. Thanks. -->

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] All tests and linting (`npm run checks`) has passed locally and any fixes were made for failures
- [x] I kept my pull requests small so it can be reviewed easier

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behaviour?

If a local .git-coauthor file is fine it will write the changes their instead of globally.

Issue URL:

## What is the new behaviour?

Creating a global .git-coauthor file will only check and create a global file.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

