### PR TITLE
Fix no path to template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ Follows [Semantic Versioning](https://semver.org/).
 
 ## git-mob-core Next
 
+## git-mob-core 0.9.3
+
+### Added
+
 - Migrate git template `git-messages` function to TypeScript.
+
+### Fixes
+
+- When no path set for the commit template, default to the global template. Don't use a relative path.
 
 ## git-mob-core 0.9.2
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12213,7 +12213,7 @@
       }
     },
     "packages/git-mob-core": {
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "MIT",
       "devDependencies": {
         "@jest/globals": "^29.7.0",

--- a/packages/git-mob-core/package-lock.json
+++ b/packages/git-mob-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@git-mob/core",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@git-mob/core",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.6",

--- a/packages/git-mob-core/package.json
+++ b/packages/git-mob-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-mob-core",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Git Mob Core library to manage co-authoring",
   "homepage": "https://github.com/rkotze/git-mob/blob/master/packages/git-mob-core/README.md",
   "main": "./dist/index.js",

--- a/packages/git-mob-core/src/git-mob-api/resolve-git-message-path.ts
+++ b/packages/git-mob-core/src/git-mob-api/resolve-git-message-path.ts
@@ -1,4 +1,4 @@
-import { resolve, relative, join } from 'node:path';
+import { resolve, join } from 'node:path';
 import { homedir } from 'node:os';
 import { topLevelDirectory } from './git-rev-parse.js';
 import { getConfig, setConfig } from './exec-command.js';
@@ -17,11 +17,11 @@ async function resolveGitMessagePath(templatePath?: string) {
 
   if (templatePath) return resolve(await topLevelDirectory(), templatePath);
 
-  return relative(await topLevelDirectory(), gitMessagePath());
+  return resolve(gitMessagePath());
 }
 
 function gitMessagePath() {
-  return process.env.GITMOB_MESSAGE_PATH || join(homedir(), '.gitmessage');
+  return join(homedir(), '.gitmessage');
 }
 
 export { resolveGitMessagePath, setCommitTemplate };


### PR DESCRIPTION
Return a valid path to the global git template. This is the correct git-mob default config.

This fixes an error that appears in vscode extension and breaks it. 

https://github.com/rkotze/git-mob-vs-code/issues/302

<!-- See our contributing guide https://github.com/rkotze/git-mob/blob/master/CONTRIBUTING.md -->

## Pull request checklist

<!-- Start your PR as draft and when you check all requirements below enable for review. Thanks. -->

No tests needed.

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] All tests and linting (`npm run checks`) has passed locally and any fixes were made for failures
- [x] I kept my pull requests small so it can be reviewed easier

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
