### PR TITLE
Refactor to have a public message format function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 Follows [Semantic Versioning](https://semver.org/).
 
-## git-mob-core Next
-
 ## git-mob 4.0.0
 
 ### Added
@@ -16,6 +14,12 @@ Follows [Semantic Versioning](https://semver.org/).
 - Removed the following commands because I think they are low value to maintain. See readme on how to edit/delete co-authors.
   - `git delete-coauthor`
   - `git edit-coauthor`
+
+## git-mob-core 0.10.0
+
+### Added
+
+- Expose a public function to format Git message co-author trailers in one place. For consumers like Git Mob VS Code extension.
 
 ## git-mob-core 0.9.3
 

--- a/packages/git-mob-core/README.md
+++ b/packages/git-mob-core/README.md
@@ -24,6 +24,7 @@ createCoAuthorsFile(authors: Author[]): <Promise<boolean>>
 updateGitTemplate(selectedAuthors?: Author[]): void
 solo(): <Promise<void>>
 setCoAuthors(keys: string[]): <Promise<Author[]>>
+messageFormatter(txt: string, authors: Author[]): string
 
 // Read actions
 getAllAuthors(): <Promise<Author[]>>
@@ -66,7 +67,7 @@ gitConfig = {
 
 ### Author class
 
-Main class for Author data exchange between function.
+Do not change the structure of the class.
 
 ```TS
 class Author;
@@ -75,6 +76,7 @@ class Author;
 Author.key: string
 Author.name: string
 Author.email: string
+Author.trailer: AuthorTrailers // defaults to AuthorTrailers.CoAuthorBy
 
 //Methods
 Author.format(): string

--- a/packages/git-mob-core/src/git-mob-api/author.ts
+++ b/packages/git-mob-core/src/git-mob-api/author.ts
@@ -4,7 +4,7 @@ export class Author {
   key: string;
   name: string;
   email: string;
-  trailer: string;
+  trailer: AuthorTrailers;
 
   constructor(
     key: string,

--- a/packages/git-mob-core/src/git-mob-api/author.ts
+++ b/packages/git-mob-core/src/git-mob-api/author.ts
@@ -1,3 +1,5 @@
+import { AuthorTrailers } from './git-message/message-formatter';
+
 export class Author {
   key: string;
   name: string;
@@ -9,8 +11,8 @@ export class Author {
     this.email = email;
   }
 
-  format() {
-    return `Co-authored-by: ${this.toString()}`;
+  format(trailer: AuthorTrailers = AuthorTrailers.CoAuthorBy) {
+    return `${trailer} ${this.toString()}`;
   }
 
   toString() {

--- a/packages/git-mob-core/src/git-mob-api/author.ts
+++ b/packages/git-mob-core/src/git-mob-api/author.ts
@@ -4,15 +4,22 @@ export class Author {
   key: string;
   name: string;
   email: string;
+  trailer: string;
 
-  constructor(key: string, name: string, email: string) {
+  constructor(
+    key: string,
+    name: string,
+    email: string,
+    trailer: AuthorTrailers = AuthorTrailers.CoAuthorBy
+  ) {
     this.key = key;
     this.name = name;
     this.email = email;
+    this.trailer = trailer;
   }
 
-  format(trailer: AuthorTrailers = AuthorTrailers.CoAuthorBy) {
-    return `${trailer} ${this.toString()}`;
+  format() {
+    return `${this.trailer} ${this.toString()}`;
   }
 
   toString() {

--- a/packages/git-mob-core/src/git-mob-api/git-authors/fetch-github-authors.spec.ts
+++ b/packages/git-mob-core/src/git-mob-api/git-authors/fetch-github-authors.spec.ts
@@ -1,4 +1,5 @@
 import { type BasicResponse, httpFetch } from '../fetch/http-fetch';
+import { AuthorTrailers } from '../git-message/message-formatter';
 import { fetchGitHubAuthors, searchGitHubAuthors } from './fetch-github-authors';
 
 jest.mock('../fetch/http-fetch');
@@ -68,6 +69,7 @@ test('Query for one GitHub user and return in AuthorList', async () => {
       key: 'dideler',
       name: 'Dennis',
       email: '345+dideler@users.noreply.github.com',
+      trailer: AuthorTrailers.CoAuthorBy,
     },
   ]);
 });
@@ -87,11 +89,13 @@ test('Query for two GitHub users and build AuthorList', async () => {
       key: 'dideler',
       name: 'Dennis',
       email: '345+dideler@users.noreply.github.com',
+      trailer: AuthorTrailers.CoAuthorBy,
     },
     {
       key: 'rkotze',
       name: 'Richard Kotze',
       email: '123+rkotze@users.noreply.github.com',
+      trailer: AuthorTrailers.CoAuthorBy,
     },
   ]);
 });
@@ -112,6 +116,7 @@ test('Handle GitHub user with no name', async () => {
       key: 'kotze',
       name: 'kotze',
       email: '329+kotze@users.noreply.github.com',
+      trailer: AuthorTrailers.CoAuthorBy,
     },
   ]);
 });
@@ -159,11 +164,13 @@ test('Search for users by name', async () => {
       key: 'dideler',
       name: 'Dennis',
       email: '345+dideler@users.noreply.github.com',
+      trailer: AuthorTrailers.CoAuthorBy,
     },
     {
       key: 'rkotze',
       name: 'Richard Kotze',
       email: '123+rkotze@users.noreply.github.com',
+      trailer: AuthorTrailers.CoAuthorBy,
     },
   ]);
 });

--- a/packages/git-mob-core/src/git-mob-api/git-message/index.spec.ts
+++ b/packages/git-mob-core/src/git-mob-api/git-message/index.spec.ts
@@ -1,18 +1,20 @@
 import { EOL } from 'node:os';
-import { jest } from '@jest/globals';
+import { readFile, writeFile } from 'node:fs/promises';
 import { Author } from '../author.js';
 import { gitMessage } from './index.js';
 
+jest.mock('node:fs/promises');
+
 test('Append co-authors to .gitmessage append file mock', async () => {
-  const appendMock = jest.fn(async () => undefined);
-  const message = gitMessage('.git/.gitmessage', appendMock);
+  const message = gitMessage('.fake/.gitmessage');
   await message.writeCoAuthors([
     new Author('jd', 'Jane Doe', 'jane@findmypast.com'),
     new Author('fb', 'Frances Bar', 'frances-bar@findmypast.com'),
   ]);
 
-  expect(appendMock).toHaveBeenCalledTimes(1);
-  expect(appendMock).toHaveBeenCalledWith(
+  expect(readFile).toHaveBeenCalledTimes(1);
+  expect(writeFile).toHaveBeenCalledTimes(1);
+  expect(writeFile).toHaveBeenCalledWith(
     expect.stringContaining('.gitmessage'),
     [
       EOL,

--- a/packages/git-mob-core/src/git-mob-api/git-message/message-formatter.spec.ts
+++ b/packages/git-mob-core/src/git-mob-api/git-message/message-formatter.spec.ts
@@ -1,0 +1,51 @@
+import { EOL } from 'node:os';
+import { Author } from '../author';
+import { messageFormatter } from './message-formatter';
+
+test('MessageFormatter: No authors to append to git message', () => {
+  const txt = `git message`;
+  const message = messageFormatter(txt, []);
+
+  expect(message).toBe(txt);
+});
+
+test('MessageFormatter: Append co-authors to git message', () => {
+  const txt = `git message`;
+  const message = messageFormatter(txt, [
+    new Author('jd', 'Jane Doe', 'jane@gitmob.com'),
+    new Author('fb', 'Frances Bar', 'frances-bar@gitmob.com'),
+  ]);
+
+  expect(message).toBe(
+    [
+      txt,
+      EOL,
+      EOL,
+      'Co-authored-by: Jane Doe <jane@gitmob.com>',
+      EOL,
+      'Co-authored-by: Frances Bar <frances-bar@gitmob.com>',
+    ].join('')
+  );
+});
+
+test('MessageFormatter: Replace co-author in the git message', () => {
+  const firstLine = 'git message';
+  const txt = [
+    firstLine,
+    EOL,
+    EOL,
+    'Co-authored-by: Jane Doe <jane@gitmob.com>',
+  ].join('');
+  const message = messageFormatter(txt, [
+    new Author('fb', 'Frances Bar', 'frances-bar@gitmob.com'),
+  ]);
+
+  expect(message).toBe(
+    [
+      firstLine,
+      EOL,
+      EOL,
+      'Co-authored-by: Frances Bar <frances-bar@gitmob.com>',
+    ].join('')
+  );
+});

--- a/packages/git-mob-core/src/git-mob-api/git-message/message-formatter.spec.ts
+++ b/packages/git-mob-core/src/git-mob-api/git-message/message-formatter.spec.ts
@@ -1,6 +1,6 @@
 import { EOL } from 'node:os';
 import { Author } from '../author';
-import { AuthorTrailers, messageFormatter } from './message-formatter';
+import { messageFormatter } from './message-formatter';
 
 test('MessageFormatter: No authors to append to git message', () => {
   const txt = `git message`;
@@ -50,17 +50,11 @@ test('MessageFormatter: Replace co-author in the git message', () => {
   );
 });
 
-test('MessageFormatter: Append a signed-off-by authors to git message', () => {
+test('MessageFormatter: Replace co-author in the git message with no line break', () => {
   const firstLine = 'git message';
-  const txt = [
-    firstLine,
-    EOL,
-    EOL,
-    'Co-authored-by: Frances Bar <frances-bar@gitmob.com>',
-  ].join('');
+  const txt = [firstLine, 'Co-authored-by: Jane Doe <jane@gitmob.com>'].join('');
   const message = messageFormatter(txt, [
     new Author('fb', 'Frances Bar', 'frances-bar@gitmob.com'),
-    new Author('jd', 'Jane Doe', 'jane@gitmob.com', AuthorTrailers.SignedBy),
   ]);
 
   expect(message).toBe(
@@ -69,8 +63,6 @@ test('MessageFormatter: Append a signed-off-by authors to git message', () => {
       EOL,
       EOL,
       'Co-authored-by: Frances Bar <frances-bar@gitmob.com>',
-      EOL,
-      'Signed-off-by: Jane Doe <jane@gitmob.com>',
     ].join('')
   );
 });

--- a/packages/git-mob-core/src/git-mob-api/git-message/message-formatter.spec.ts
+++ b/packages/git-mob-core/src/git-mob-api/git-message/message-formatter.spec.ts
@@ -1,6 +1,6 @@
 import { EOL } from 'node:os';
 import { Author } from '../author';
-import { messageFormatter } from './message-formatter';
+import { AuthorTrailers, messageFormatter } from './message-formatter';
 
 test('MessageFormatter: No authors to append to git message', () => {
   const txt = `git message`;
@@ -46,6 +46,31 @@ test('MessageFormatter: Replace co-author in the git message', () => {
       EOL,
       EOL,
       'Co-authored-by: Frances Bar <frances-bar@gitmob.com>',
+    ].join('')
+  );
+});
+
+test('MessageFormatter: Append a signed-off-by authors to git message', () => {
+  const firstLine = 'git message';
+  const txt = [
+    firstLine,
+    EOL,
+    EOL,
+    'Co-authored-by: Frances Bar <frances-bar@gitmob.com>',
+  ].join('');
+  const message = messageFormatter(txt, [
+    new Author('fb', 'Frances Bar', 'frances-bar@gitmob.com'),
+    new Author('jd', 'Jane Doe', 'jane@gitmob.com', AuthorTrailers.SignedBy),
+  ]);
+
+  expect(message).toBe(
+    [
+      firstLine,
+      EOL,
+      EOL,
+      'Co-authored-by: Frances Bar <frances-bar@gitmob.com>',
+      EOL,
+      'Signed-off-by: Jane Doe <jane@gitmob.com>',
     ].join('')
   );
 });

--- a/packages/git-mob-core/src/git-mob-api/git-message/message-formatter.ts
+++ b/packages/git-mob-core/src/git-mob-api/git-message/message-formatter.ts
@@ -1,0 +1,21 @@
+import { EOL } from 'node:os';
+import { type Author } from '../author';
+
+enum AuthorTrailers {
+  CoAuthorBy = 'Co-authored-by:',
+}
+
+export function messageFormatter(
+  txt: string,
+  authors: Author[],
+  trailer: AuthorTrailers = AuthorTrailers.CoAuthorBy
+): string {
+  const message = txt.replaceAll(/(\r\n|\r|\n){1,2}Co-authored-by.*/g, '');
+
+  if (authors && authors.length > 0) {
+    const authorTrailerTxt = authors.map(author => author.format()).join(EOL);
+    return [message, EOL, EOL, authorTrailerTxt].join('');
+  }
+
+  return message;
+}

--- a/packages/git-mob-core/src/git-mob-api/git-message/message-formatter.ts
+++ b/packages/git-mob-core/src/git-mob-api/git-message/message-formatter.ts
@@ -1,7 +1,7 @@
 import { EOL } from 'node:os';
 import { type Author } from '../author';
 
-enum AuthorTrailers {
+export enum AuthorTrailers {
   CoAuthorBy = 'Co-authored-by:',
 }
 
@@ -10,7 +10,8 @@ export function messageFormatter(
   authors: Author[],
   trailer: AuthorTrailers = AuthorTrailers.CoAuthorBy
 ): string {
-  const message = txt.replaceAll(/(\r\n|\r|\n){1,2}Co-authored-by.*/g, '');
+  const regex = new RegExp(`(\r\n|\r|\n){1,2}${trailer}.*`, 'g');
+  const message = txt.replaceAll(regex, '');
 
   if (authors && authors.length > 0) {
     const authorTrailerTxt = authors.map(author => author.format()).join(EOL);

--- a/packages/git-mob-core/src/git-mob-api/git-message/message-formatter.ts
+++ b/packages/git-mob-core/src/git-mob-api/git-message/message-formatter.ts
@@ -3,14 +3,12 @@ import { type Author } from '../author';
 
 export enum AuthorTrailers {
   CoAuthorBy = 'Co-authored-by:',
+  SignedBy = 'Signed-off-by:',
 }
 
-export function messageFormatter(
-  txt: string,
-  authors: Author[],
-  trailer: AuthorTrailers = AuthorTrailers.CoAuthorBy
-): string {
-  const regex = new RegExp(`(\r\n|\r|\n){1,2}${trailer}.*`, 'g');
+export function messageFormatter(txt: string, authors: Author[]): string {
+  const trailers = Object.values(AuthorTrailers).join('|');
+  const regex = new RegExp(`(\r\n|\r|\n){1,2}(${trailers}).*`, 'g');
   const message = txt.replaceAll(regex, '');
 
   if (authors && authors.length > 0) {

--- a/packages/git-mob-core/src/git-mob-api/git-message/message-formatter.ts
+++ b/packages/git-mob-core/src/git-mob-api/git-message/message-formatter.ts
@@ -3,12 +3,11 @@ import { type Author } from '../author';
 
 export enum AuthorTrailers {
   CoAuthorBy = 'Co-authored-by:',
-  SignedBy = 'Signed-off-by:',
 }
 
 export function messageFormatter(txt: string, authors: Author[]): string {
-  const trailers = Object.values(AuthorTrailers).join('|');
-  const regex = new RegExp(`(\r\n|\r|\n){1,2}(${trailers}).*`, 'g');
+  const trailers = AuthorTrailers.CoAuthorBy;
+  const regex = new RegExp(`(\r\n|\r|\n){0,2}(${trailers}).*`, 'g');
   const message = txt.replaceAll(regex, '');
 
   if (authors && authors.length > 0) {

--- a/packages/git-mob-core/src/index.ts
+++ b/packages/git-mob-core/src/index.ts
@@ -143,3 +143,4 @@ export {
 } from './git-mob-api/git-authors/fetch-github-authors.js';
 export { getConfig, updateConfig } from './config-manager.js';
 export { Author } from './git-mob-api/author.js';
+export { messageFormatter } from './git-mob-api/git-message/message-formatter.js';

--- a/packages/git-mob/README.md
+++ b/packages/git-mob/README.md
@@ -225,7 +225,7 @@ $ git add-coauthor bb "Barry Butterworth" barry@butterworth.org
 
 ### Suggest co-authors
 
-Suggest co-authors to save based on contributors to the current Git repository.
+Suggest co-authors from contributors in local Git repository and add to `.git-coauthors` file.
 
 Optional author filter by name or email.
 


### PR DESCRIPTION
## Refactor description

Public API for git mob core will have a message formatter function to handle co-author trailers only. This should be used in consuming apps to format git message co-author trailers like Git Mob VS Code.

This has been built for extension in mind at a later point to support multiple trailers.

## Pull request checklist

<!-- Start your PR as draft and when you check all requirements below enable for review. Thanks. -->

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Updated the `CHANGELOG.md` to capture my changes
- [x] Build (`npm run build`) was successfully run locally
- [x] All tests and linting (`npm run checks`) has passed locally
- [x] I kept my pull requests small so it can be reviewed easier

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Refactor

## Does this introduce a breaking change?

- [x] No

