### PR TITLE
Fix co-author email filtering by exact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Follows [Semantic Versioning](https://semver.org/).
 
+## git-mob-core 0.10.1
+
+### Fixed
+
+- If an email has partially the same email as another co-author they will get included. This addresses this issue. [Issue 213](https://github.com/rkotze/git-mob/issues/213)
+
 ## git-mob 4.0.0
 
 ### Added

--- a/packages/git-mob-core/src/index.spec.ts
+++ b/packages/git-mob-core/src/index.spec.ts
@@ -32,6 +32,7 @@ const mockedGetSetCoAuthors = jest.mocked(getSetCoAuthors);
 describe('Git Mob core API', () => {
   afterEach(() => {
     mockedRemoveGitMobSection.mockReset();
+    mockedGetSetCoAuthors.mockReset();
     mockedGitConfig.getGlobalCommitTemplate.mockReset();
     mockedGitConfig.getLocalCommitTemplate.mockReset();
   });
@@ -137,6 +138,17 @@ describe('Git Mob core API', () => {
     const selectedAuthor = listAll[1];
     mockedGetSetCoAuthors.mockResolvedValueOnce(selectedAuthor.toString());
     const selected = await getSelectedCoAuthors(listAll);
+
+    expect(mockedGetSetCoAuthors).toHaveBeenCalledTimes(1);
+    expect(selected).toEqual([selectedAuthor]);
+  });
+
+  it('Use exact email for selected co-authors', async () => {
+    const listAll = buildAuthorList(['ab', 'efcd', 'cd']);
+    const selectedAuthor = listAll[1];
+    mockedGetSetCoAuthors.mockResolvedValueOnce(selectedAuthor.toString());
+    const selected = await getSelectedCoAuthors(listAll);
+
     expect(mockedGetSetCoAuthors).toHaveBeenCalledTimes(1);
     expect(selected).toEqual([selectedAuthor]);
   });

--- a/packages/git-mob-core/src/index.ts
+++ b/packages/git-mob-core/src/index.ts
@@ -84,7 +84,7 @@ async function getSelectedCoAuthors(allAuthors: Author[]) {
   const coAuthorConfigValue = await getSetCoAuthors();
   if (coAuthorConfigValue) coAuthorsString = coAuthorConfigValue;
 
-  return allAuthors.filter(author => coAuthorsString.includes(author.email));
+  return allAuthors.filter(author => coAuthorsString.includes('<' + author.email));
 }
 
 async function solo() {


### PR DESCRIPTION
## Description

If an email has partially the same email as another co-author they will get included in commands like `git mob-print` or `git mob`.

Issue URL: #213

## Pull request checklist

<!-- Start your PR as draft and when you check all requirements below enable for review. Thanks. -->

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Updated the `CHANGELOG.md` to capture my changes
- [x] Build (`npm run build`) was successfully run locally
- [x] All tests and linting (`npm run checks`) has passed locally
- [x] I kept my pull requests small so it can be reviewed easier

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bug fix

## Does this introduce a breaking change?

- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
